### PR TITLE
Feature/travis ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,14 @@ language: c
 before_install:
   - "/sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_1.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :1 -ac -screen 0 1280x1024x16"
   - sleep 3
+  - ARD_VER="1.8.7"
   - export DISPLAY=:1.0
-  - wget http://downloads.arduino.cc/arduino-1.8.7-linux64.tar.xz
-  - tar xf arduino-1.8.7-linux64.tar.xz
+  - echo "Downloading version $ARD_VER of the Arduino IDE..."
+  - wget http://downloads.arduino.cc/arduino-$ARD_VER-linux64.tar.xz
+  - tar xf arduino-$ARD_VER-linux64.tar.xz
   - git clone https://github.com/jrowberg/i2cdevlib.git
-  - sudo mv i2cdevlib/Arduino/* arduino-1.8.7/libraries
-  - sudo mv arduino-1.8.7 /usr/local/share/arduino
+  - sudo mv i2cdevlib/Arduino/* arduino-$ARD_VER/libraries
+  - sudo mv arduino-$ARD_VER /usr/local/share/arduino
   - sudo ln -s /usr/local/share/arduino/arduino /usr/local/bin/arduino
 install:
   - arduino --install-library "Adafruit SleepyDog Library,Adafruit MQTT Library"

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ before_install:
   - sleep 3
   - export DISPLAY=:1.0
 install:
-  - ./bin/install_dependencies.sh
+  - bash bin/install_dependencies.sh
 script:
   - arduino --verify --board arduino:avr:micro main/main.ino
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,7 @@
 language: c
 before_install:
   - "/sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_1.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :1 -ac -screen 0 1280x1024x16"
-  - sleep 3
-  - export DISPLAY=:1.0
 install:
   - bash bin/install_dependencies.sh
 script:
   - arduino --verify --board arduino:avr:micro main/main.ino
-notifications:
-  email:
-    on_success: change
-    on_failure: change

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,17 +2,9 @@ language: c
 before_install:
   - "/sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_1.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :1 -ac -screen 0 1280x1024x16"
   - sleep 3
-  - ARD_VER="1.8.7"
   - export DISPLAY=:1.0
-  - echo "Downloading version $ARD_VER of the Arduino IDE..."
-  - wget http://downloads.arduino.cc/arduino-$ARD_VER-linux64.tar.xz
-  - tar xf arduino-$ARD_VER-linux64.tar.xz
-  - git clone https://github.com/jrowberg/i2cdevlib.git
-  - sudo mv i2cdevlib/Arduino/* arduino-$ARD_VER/libraries
-  - sudo mv arduino-$ARD_VER /usr/local/share/arduino
-  - sudo ln -s /usr/local/share/arduino/arduino /usr/local/bin/arduino
 install:
-  - arduino --install-library "Adafruit SleepyDog Library,Adafruit MQTT Library"
+  - ./bin/install_dependencies.sh
 script:
   - arduino --verify --board arduino:avr:micro main/main.ino
 notifications:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,14 @@
 # LYNCS-rover
 [![Build Status](https://travis-ci.com/LYNCS-Keio/LYNCS-rover.svg?branch=master)](https://travis-ci.com/LYNCS-Keio/LYNCS-rover)  
 2019種子島宇宙ロケットコンテストヘ向けたローバーのプログラム
-## How to contribute
+## How to Contribute
 See [Let's-get-start-with-git!](https://github.com/LYNCS-Keio/LYNCS-rover/wiki/Let's-get-start-with-git!)
+## How to Start
+Ubuntu等で`git clone`した後ターミナルで以下を実行するとこのプロジェクトに使われている
+Arduino環境を自動で構築してくれます. 自分でArduino環境を構築したい場合は注意してください. 
+```sh
+bash bin/install_dependencies.sh
+```
+## Requirement for Arduino
+- Arduino IDE > 1.8.7
+- i2cdevlib (https://github.com/jrowberg/i2cdevlib)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # LYNCS-rover
-[![Build Status](https://travis-ci.com/LYNCS-Keio/LYNCS-rover.svg?branch=master)](https://travis-ci.com/LYNCS-Keio/LYNCS-rover)  
+[![Build Status](https://travis-ci.com/LYNCS-Keio/LYNCS-rover.svg?branch=develop)](https://travis-ci.com/LYNCS-Keio/LYNCS-rover)  
 2019種子島宇宙ロケットコンテストヘ向けたローバーのプログラム
 ## How to Contribute
 See [Let's-get-start-with-git!](https://github.com/LYNCS-Keio/LYNCS-rover/wiki/Let's-get-start-with-git!)

--- a/bin/install_dependencies.sh
+++ b/bin/install_dependencies.sh
@@ -3,7 +3,6 @@ echo "Downloading version $ARD_VER of the Arduino IDE..."
 wget http://downloads.arduino.cc/arduino-$ARD_VER-linux64.tar.xz
 tar xf arduino-$ARD_VER-linux64.tar.xz
 git clone https://github.com/jrowberg/i2cdevlib.git
-sudo mv i2cdevlib/Arduino/* arduino-$ARD_VER/libraries
+mv i2cdevlib/Arduino/* arduino-$ARD_VER/libraries
 sudo mv arduino-$ARD_VER /usr/local/share/arduino
 sudo ln -s /usr/local/share/arduino/arduino /usr/local/bin/arduino
-arduino --install-library "Adafruit SleepyDog Library,Adafruit MQTT Library"

--- a/bin/install_dependencies.sh
+++ b/bin/install_dependencies.sh
@@ -1,0 +1,9 @@
+ARD_VER="1.8.7"
+echo "Downloading version $ARD_VER of the Arduino IDE..."
+wget http://downloads.arduino.cc/arduino-$ARD_VER-linux64.tar.xz
+tar xf arduino-$ARD_VER-linux64.tar.xz
+git clone https://github.com/jrowberg/i2cdevlib.git
+sudo mv i2cdevlib/Arduino/* arduino-$ARD_VER/libraries
+sudo mv arduino-$ARD_VER /usr/local/share/arduino
+sudo ln -s /usr/local/share/arduino/arduino /usr/local/bin/arduino
+arduino --install-library "Adafruit SleepyDog Library,Adafruit MQTT Library"

--- a/bin/install_dependencies.sh
+++ b/bin/install_dependencies.sh
@@ -1,8 +1,7 @@
 ARD_VER="1.8.7"
 echo "Downloading version $ARD_VER of the Arduino IDE..."
-wget http://downloads.arduino.cc/arduino-$ARD_VER-linux64.tar.xz
-tar xf arduino-$ARD_VER-linux64.tar.xz
-git clone https://github.com/jrowberg/i2cdevlib.git
+curl  http://downloads.arduino.cc/arduino-1.8.7-linux64.tar.xz | tar Jxfv -
+git clone --depth 1 https://github.com/jrowberg/i2cdevlib.git
 mv i2cdevlib/Arduino/* arduino-$ARD_VER/libraries
 sudo mv arduino-$ARD_VER /usr/local/share/arduino
 sudo ln -s /usr/local/share/arduino/arduino /usr/local/bin/arduino


### PR DESCRIPTION
travis ciの設定の改善。
Linux/Mac環境なら/bin/install_dependencies.sh を動かすとこのプログラムで使われているArduino環境をインストールできます。